### PR TITLE
Updating README to include information about formatting of AUTH_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,10 @@ https://authorization-server.com/oauth/authorize
 	?client_id=REPLACE_WITH_CLIENT_ID
 	&response_type=code
 	&state=REPLACE_WITH_STATE
-	&redirect_uri=https%3A%2F%2Fexample-app.com%2Fauth
+	&redirect_uri=http%3A%2F%localhost%3A3000
 ```
+
+This example app does not use a specific callback endpoint currently and just expects the redirect_uri to be the index of the host domain.
 
 ## Public Domain
 This repository constitutes a work of the United States Government and is not

--- a/README.md
+++ b/README.md
@@ -57,6 +57,17 @@ This app is able to run in a configuration where a OAuth 2.0 access token is nee
 - `SECURE_MODE=true` to run in the secure mode configuration
 - `AUTH_URL=https://authorization-server.com/oauth/authorize` the value for the authorization URL from your OAuth 2.0 provider
 
+Your `AUTH_URL` should follow the [general guidelines for a Single Page App](https://www.oauth.com/oauth2-servers/single-page-apps/).
+The following is an example of what this URL might look like and how your `redirect_uri` should be formatted:
+
+```
+https://authorization-server.com/oauth/authorize
+	?client_id=REPLACE_WITH_CLIENT_ID
+	&response_type=code
+	&state=REPLACE_WITH_STATE
+	&redirect_uri=https%3A%2F%2Fexample-app.com%2Fauth
+```
+
 ## Public Domain
 This repository constitutes a work of the United States Government and is not
 subject to domestic copyright protection under 17 USC § 105. This repository is in


### PR DESCRIPTION
This PR contains some basic information explaining how the `AUTH_URL` and the attached `redirect_uri` should be formatted in case the person viewing is not familiar with OAuth standards. 